### PR TITLE
add word boundary to trimmed word

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const bannedRegex = banned.reduce((arr, b) => {
   starts.forEach(s => {
     const trimmed = b.replace(s, '').trim();
     if (b.startsWith(s) && arr.indexOf(trimmed) === -1)
-      arr.push(`${s}\\s(.*?)\\s${trimmed}`);
+      arr.push(`${s}\\s(.*?)\\s${trimmed}\\b`);
   });
   return arr;
 }, []);

--- a/test.js
+++ b/test.js
@@ -89,8 +89,6 @@ describe('remark-lint-link-text', () => {
     });
   });
 
-  //
-
   test('warns against banned link text, regex match', () => {
     const lint = processMarkdown(
       dedent`

--- a/test.js
+++ b/test.js
@@ -75,6 +75,22 @@ describe('remark-lint-link-text', () => {
     });
   });
 
+  test('the...documentation should pass', () => {
+    const lint = processMarkdown(
+      dedent`
+      # Title
+
+      A good link: [the Mapbox Isochrone API documentation](https://docs.mapbox.com).
+    `
+    );
+
+    return lint.then(vFile => {
+      expect(vFile.messages.length).toBe(0);
+    });
+  });
+
+  //
+
   test('warns against banned link text, regex match', () => {
     const lint = processMarkdown(
       dedent`


### PR DESCRIPTION
The rule that looks for link text like: `[the any word here document](#)` was picking up link text ending with the word `documentation`. This PR fixes the regex to match the whole word `document`.

cc @langsmith 