### PR TITLE
Fix greedy regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const bannedRegex = banned.reduce((arr, b) => {
   starts.forEach((s) => {
     const trimmed = b.replace(s, '').trim();
     if (b.startsWith(s) && arr.indexOf(trimmed) === -1)
-      arr.push(`${s}\\s(.*?)\\s${trimmed}\\b`);
+      arr.push(`${s}\\s(.*?)\\s${trimmed}\\b$`);
   });
   return arr;
 }, []);

--- a/test.js
+++ b/test.js
@@ -87,6 +87,20 @@ describe('remark-lint-link-text', () => {
     });
   });
 
+  test('should pass', () => {
+    const lint = processMarkdown(
+      dedent`
+      ## Option 1: Choropleth
+      
+      In this option, we will create a choropleth visualization using data from [The Washington Post's "2ºC: Beyond the Limit" series about rising temperatures](https://github.com/washingtonpost/data-2C-beyond-the-limit-usa), which analyzes warming temperatures in the United States.
+    `
+    );
+
+    return lint.then((vFile) => {
+      expect(vFile.messages.length).toBe(0);
+    });
+  });
+
   test('warns against banned link text, regex match', () => {
     const lint = processMarkdown(
       dedent`


### PR DESCRIPTION
In https://github.com/mapbox/help/pull/2823, the following link text is failing:

> [The Washington Post's "2ºC: Beyond the Limit" series about rising temperature](...)

This is because the wants to make sure that the link text does not say [the post](...), which is not descriptive, and the regex test was casting a wide net and caught the link text above. This PR adjusts the regex.