### PR TITLE
Adding CodeOwners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @mapbox/docs


### PR DESCRIPTION
Adds the codeowners file to declare the docs team as owners of this repository