### PR TITLE
Removed Travis CI & added GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: remark-lint-link-text
+on:
+  push:
+    branches:
+      - main 
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up Node.js environment using the specified versions
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # Install dependencies using npm
+      - name: Install dependencies
+        run: npm install
+
+      # Run the tests
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-dist: jammy
-
-language: node_js
-node_js:
-  - 18


### PR DESCRIPTION
Removes `travis.yml` and adds github actions.  Uses slightly different steps from our other docs repos since this is a public repo.