### PR TITLE
Update engines to node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,10 @@
         "lint-staged": "^15",
         "prettier": "^3",
         "remark": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,9 @@
   "bugs": {
     "url": "https://github.com/mapbox/remark-lint-link-text/issues"
   },
-  "homepage": "https://github.com/mapbox/remark-lint-link-text#readme"
+  "homepage": "https://github.com/mapbox/remark-lint-link-text#readme",
+  "engines": {
+    "node": ">=20",
+    "npm": ">=10"
+  }
 }


### PR DESCRIPTION
This PR updates engines in package.json to require Node >=20 and npm >=10.